### PR TITLE
M1W: Map Fn + Esc to QK_BOOT

### DIFF
--- a/keyboards/monsgeek/m1w/keymaps/via/keymap.c
+++ b/keyboards/monsgeek/m1w/keymaps/via/keymap.c
@@ -15,7 +15,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     [1] = LAYOUT(
-        _______, KC_MYCM, KC_MAIL, LGUI(KC_S), KC_WHOM, KC_MSEL, KC_MPLY, KC_MPRV, KC_MNXT, _______, _______, _______, _______, _______,       _______,
+        QK_BOOT, KC_MYCM, KC_MAIL, LGUI(KC_S), KC_WHOM, KC_MSEL, KC_MPLY, KC_MPRV, KC_MNXT, _______, _______, _______, _______, _______,       _______,
         EE_CLR,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, RGB_SPD, RGB_SPI, _______,          _______,
         _______, _______, KC_WASD, KC_BT1,  KC_BT2,  KC_BT3,  KC_2G4,  KC_USB,  KC_INS, _______,  KC_PSCR, _______, _______, RGB_MOD,          _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, RGB_TOG, _______, _______,          _______,          _______,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

[Please read my PR in the main repository for more context.](https://github.com/MonsGeek/qmk_firmware/pull/2)

## Description

- Map `Fn` + `Esc` to `QK_BOOT`, so it's possible to reset to bootloader using this key combination

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [ ] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [ ] The Vendor ID is not `0xFEED`
